### PR TITLE
Revert "Update descriptors.py correcting lipinski issue"

### DIFF
--- a/game_scripts/descriptors.py
+++ b/game_scripts/descriptors.py
@@ -67,10 +67,10 @@ def lipinski(desc_dict):
     Return the number of rules broken and whether the molecule passes.
     """
     violations = 0
-    if desc_dict['MW'] > 500: violations += 1
-    if desc_dict['h_acc'] > 10: violations += 1
-    if desc_dict['h_don'] > 5: violations += 1
-    if desc_dict['logP'] > 5: violations += 1
+    if desc_dict['MW'] >= 500: violations += 1
+    if desc_dict['h_acc'] >= 10: violations += 1
+    if desc_dict['h_don'] >= 5: violations += 1
+    if desc_dict['logP'] >= 5: violations += 1
     if violations > 1:
         result = 'fails'
     else:


### PR DESCRIPTION
Reverts SABSR3-Group-2/drug_discovery_game#102 as molecular wait and log p should remain ">=" and only h_acc and h_don should be ">" (my fault, i over corrected)